### PR TITLE
Update for SSL github issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation is a process that lasts only a few minutes. You'll need root SSH ac
 
 _$ cd /  
 $ rm -f engintron.sh  
-$ wget [https://raw.githubusercontent.com/engintron/engintron/master/engintron.sh](https://raw.githubusercontent.com/engintron/engintron/master/engintron.sh)  
+$ wget --no-check-certificate [https://raw.githubusercontent.com/engintron/engintron/master/engintron.sh](https://raw.githubusercontent.com/engintron/engintron/master/engintron.sh)  
 $ bash engintron.sh install_
 
 The process will take a couple of minutes to complete and after that, Engintron will be installed on your cPanel server. Engintron has a nice user interface which is activated inside WHM, under the Plugins section. After installation, refresh WHM in your browser and you should see Engintron in the Plugins section (it's the absolute last section in WHM's sidebar).


### PR DESCRIPTION
Avoid the following error:

ERROR: certificate common name `www.github.com' doesn't match requested host name `raw.githubusercontent.com'.
To connect to raw.githubusercontent.com insecurely, use `--no-check-certificate'.