### PR TITLE
wordpress_logged_in pattern changes

### DIFF
--- a/nginx/proxy_params_dynamic
+++ b/nginx/proxy_params_dynamic
@@ -14,7 +14,7 @@ set $CACHE_BYPASS_FOR_DYNAMIC 0;
 set $EXPIRES_FOR_DYNAMIC "1s";
 
 # CMS (& CMS extension) specific cookies (Joomla, K2, WordPress)
-if ($http_cookie ~* "joomla_[a-zA-Z0-9_]+|userID|comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+if ($http_cookie ~* "joomla_[a-zA-Z0-9_]+|userID|comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in|wordpress_logged_in_[a-f0-9]+") {
     set $CACHE_BYPASS_FOR_DYNAMIC 1;
     set $EXPIRES_FOR_DYNAMIC 0;
 }


### PR DESCRIPTION
As a logged in user im seeing this cookies:
1) wordpress_9ff9e774000c5adb725acae80ceff674 (only backend)  
2) wordpress_logged_in_9ff9e774000c5adb725acae80ceff674  (front and backend)

the first match but the second not, so this pull add the new pattern
