### PR TITLE
webmail.domain and bypass domains 

### DIFF
--- a/nginx/bypass_domains
+++ b/nginx/bypass_domains
@@ -1,0 +1,12 @@
+#
+# /etc/nginx/bypass_domains
+#
+# Configure domains we dont want cache at all, just uncomment the if statment below.
+# Please keep in mind the more domains we bypass the less efficient nginx will be to the end user.
+#
+# Once added test nginx with nginx -t , fix error and restart. Also note replace DOMAIN part with a real domain.
+
+# if ($host ~* "DOMAIN1|DOMAIN2|DOMAIN3") {
+#    set $CACHE_BYPASS_FOR_DYNAMIC 1;
+#    set $EXPIRES_FOR_DYNAMIC 0;
+# }

--- a/nginx/conf.d/cpanel.conf
+++ b/nginx/conf.d/cpanel.conf
@@ -1,0 +1,107 @@
+# /**
+#  * @package    NGINX for cPanel/WHM
+#  * @description   Forced cacheing for slow websites, this file is managed by puppet. Changes will most likely be lost.
+#  */
+
+server {
+
+	listen 80;
+	server_name webmail.*;
+        
+        location / {
+                proxy_pass http://127.0.0.1:2095/;
+                proxy_http_version  1.1;                # Always upgrade to HTTP/1.1
+                proxy_set_header    Accept-Encoding ""; # Optimize encoding
+                proxy_set_header    Connection "";      # Enable keepalives
+                proxy_set_header    Host $host;
+                proxy_set_header    Proxy "";
+                include fastcgi_params;
+                access_log off;
+        }
+}
+
+
+server {
+
+        listen 80;
+        server_name cpanel.*;
+
+        location / {
+                proxy_pass http://127.0.0.1:2082/;
+                proxy_http_version  1.1;                # Always upgrade to HTTP/1.1
+                proxy_set_header    Accept-Encoding ""; # Optimize encoding
+                proxy_set_header    Connection "";      # Enable keepalives
+                proxy_set_header    Host $host;
+                proxy_set_header    Proxy "";
+                include fastcgi_params;
+                access_log off;
+        }
+}
+
+server {
+
+        listen 80;
+        server_name whm.*;
+
+        location / {
+                proxy_pass http://127.0.0.1:2086/;
+                proxy_http_version  1.1;                # Always upgrade to HTTP/1.1
+                proxy_set_header    Accept-Encoding ""; # Optimize encoding
+                proxy_set_header    Connection "";      # Enable keepalives
+                proxy_set_header    Host $host;
+                proxy_set_header    Proxy "";
+                include fastcgi_params;
+                access_log off;
+        }
+}
+
+server {
+
+        listen 80;
+        server_name webdisk.*;
+
+        location / {
+                proxy_pass http://127.0.0.1:2077/;
+                proxy_http_version  1.1;                # Always upgrade to HTTP/1.1
+                proxy_set_header    Accept-Encoding ""; # Optimize encoding
+                proxy_set_header    Connection "";      # Enable keepalives
+                proxy_set_header    Host $host;
+                proxy_set_header    Proxy "";
+                include fastcgi_params;
+                access_log off;
+        }
+}
+
+server {
+
+        listen 80;
+        server_name cpcalendars.*;
+
+        location / {
+                proxy_pass http://127.0.0.1:2079/;
+                proxy_http_version  1.1;                # Always upgrade to HTTP/1.1
+                proxy_set_header    Accept-Encoding ""; # Optimize encoding
+                proxy_set_header    Connection "";      # Enable keepalives
+                proxy_set_header    Host $host;
+                proxy_set_header    Proxy "";
+                include fastcgi_params;
+                access_log off;
+        }
+}
+
+server {
+
+        listen 80;
+        server_name cpcontacts.*;
+
+        location / {
+                proxy_pass http://127.0.0.1:2079/;
+                proxy_http_version  1.1;                # Always upgrade to HTTP/1.1
+                proxy_set_header    Accept-Encoding ""; # Optimize encoding
+                proxy_set_header    Connection "";      # Enable keepalives
+                proxy_set_header    Host $host;
+                proxy_set_header    Proxy "";
+                include fastcgi_params;
+                access_log off;
+        }
+}

--- a/nginx/proxy_params_dynamic
+++ b/nginx/proxy_params_dynamic
@@ -37,6 +37,9 @@ if ($query_string ~* "nocache") {
     set $EXPIRES_FOR_DYNAMIC 0;
 }
 
+# Bypass cache for domains
+include /etc/nginx/bypass_domains;
+
 proxy_no_cache          $CACHE_BYPASS_FOR_DYNAMIC;
 proxy_cache_bypass      $CACHE_BYPASS_FOR_DYNAMIC;
 


### PR DESCRIPTION
I have found that webmail.domain fails to work correctly with Horde and sometimes with SquirrelMail. Thus I have created cpanel.conf which does a proxy_pass directly to webmail ports. One small bug is that IPValid cookies will need to be set to off. Not great I know, but I am currently looking at how cPanel verifies the IP address. 

The 2nd part is bypass_domains, some of users did not want to be cached, so i enabled an option to bypass caching for a domain.

Thanks for considering my contribution