### PR TITLE
Strict-Transport-Security and extra headers

### DIFF
--- a/nginx/proxy_params_common
+++ b/nginx/proxy_params_common
@@ -43,7 +43,7 @@ proxy_send_timeout			120s;
 if ($scheme = "https") {
     # Info
     add_header                    X-Nginx-Cache-Status $upstream_cache_status;
-    add_header                    X-Server-Powered-By "My-Hosted-Website";
+    add_header                    X-Server-Powered-By "Engintron";
     
     # Security Headers
     add_header                    Strict-Transport-Security "max-age=15768000; includeSubDomains" always;
@@ -56,7 +56,7 @@ if ($scheme = "https") {
 if ($scheme = "http"){
     # Info
     add_header                    X-Nginx-Cache-Status $upstream_cache_status;
-    add_header                    X-Server-Powered-By "My-Hosted-Website";
+    add_header                    X-Server-Powered-By "Engintron";
     
     # Security Headers
     add_header                    Referrer-Policy "no-referrer-when-downgrade" always;

--- a/nginx/proxy_params_common
+++ b/nginx/proxy_params_common
@@ -49,8 +49,8 @@ if ($scheme = "https") {
     add_header                    Strict-Transport-Security "max-age=15768000; includeSubDomains" always;
     add_header                    Referrer-Policy "no-referrer-when-downgrade" always;
     add_header                    X-Frame-Options SAMEORIGIN;
-    add_header                    X-Content-Type-Options nosniff;
-    add_header                    X-XSS-Protection "1; mode=block";
+    add_header                    X-Content-Type-Options "nosniff" always;
+    add_header                    X-XSS-Protection "1; mode=block" always;
 }
 
 if ($scheme = "http"){
@@ -61,6 +61,6 @@ if ($scheme = "http"){
     # Security Headers
     add_header                    Referrer-Policy "no-referrer-when-downgrade" always;
     add_header                    X-Frame-Options SAMEORIGIN;
-    add_header                    X-Content-Type-Options nosniff;
-    add_header                    X-XSS-Protection "1; mode=block";
+    add_header                    X-Content-Type-Options "nosniff" always;
+    add_header                    X-XSS-Protection "1; mode=block" always;
 }

--- a/nginx/proxy_params_common
+++ b/nginx/proxy_params_common
@@ -40,6 +40,27 @@ proxy_connect_timeout		120s;
 proxy_read_timeout			120s;
 proxy_send_timeout			120s;
 
-# Info
-add_header					X-Cache-Status $upstream_cache_status;
-add_header					X-Server-Powered-By "Engintron";
+if ($scheme = "https") {
+    # Info
+    add_header                    X-Nginx-Cache-Status $upstream_cache_status;
+    add_header                    X-Server-Powered-By "My-Hosted-Website";
+    
+    # Security Headers
+    add_header                    Strict-Transport-Security "max-age=15768000; includeSubDomains" always;
+    add_header                    Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header                    X-Frame-Options SAMEORIGIN;
+    add_header                    X-Content-Type-Options nosniff;
+    add_header                    X-XSS-Protection "1; mode=block";
+}
+
+if ($scheme = "http"){
+    # Info
+    add_header                    X-Nginx-Cache-Status $upstream_cache_status;
+    add_header                    X-Server-Powered-By "My-Hosted-Website";
+    
+    # Security Headers
+    add_header                    Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header                    X-Frame-Options SAMEORIGIN;
+    add_header                    X-Content-Type-Options nosniff;
+    add_header                    X-XSS-Protection "1; mode=block";
+}


### PR DESCRIPTION
Fixing the Strict-Transport-Security and add other Security headers.
This does work and tested with a clean install and all the correct headers are sent with non-SSL and SSL connections. 

Adding the Strict-Transport-Security, Referrer-Policy, X-Frame-Options, X-Content-Type-Options and X-XSS-Protection headers

you can test the headers at https://securityheaders.io