### PR TITLE
Adding resolver_timeout to fix OCSP stapling

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -34,6 +34,7 @@ http {
     tcp_nodelay                    on;
     tcp_nopush                     on;
     types_hash_max_size            2048;
+    resolver_timeout               30s;
 
     ## DNS Resolver ##
     # If in China, enable the OpenDNS entry that matches your network connectivity (IPv4 only or IPv4 & IPv6)


### PR DESCRIPTION
Issues with OCSP stapling that it was failing and i added resolver_timeout 30s; and now my OCSP stapling is not failing.