### PR TITLE
Make Security Headers Optional

### DIFF
--- a/nginx/proxy_params_common
+++ b/nginx/proxy_params_common
@@ -36,8 +36,8 @@ proxy_read_timeout            240s;
 proxy_send_timeout            240s;
 
 # Security Headers
-add_header                    X-XSS-Protection "1; mode=block" always;
-add_header                    X-Content-Type-Options "nosniff" always;
+# add_header                    X-XSS-Protection "1; mode=block" always;
+# add_header                    X-Content-Type-Options "nosniff" always;
 # The HSTS header below force-redirects HTTP to HTTPS traffic & uses the browser's cache
 # to store the redirect. Comment out with caution. More info on HSTS here:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security


### PR DESCRIPTION
Make security headers optional.

I don't recommend imposing security headers by default on 
cPanel users unless the provider wants to.
Despite these headers being relatively harmless they can break
user websites on the first install. This also gives the cPanel user
the option to update their headers via .htaccess.

Signed-off-by: Gaige Lama <gaigelama@gmail.com>