### PR TITLE
joins serveraliases from multiple lines

### DIFF
--- a/engintron.sh
+++ b/engintron.sh
@@ -347,7 +347,7 @@ EOFS
 
     # Adjust log rotation to 7 days
     if [ -f /etc/logrotate.d/nginx ]; then
-        sed -i 's:rotate .*:rotate 7:' /etc/logrotate.d/nginx 
+        sed -i 's:rotate .*:rotate 7:' /etc/logrotate.d/nginx
     fi
 
     echo ""
@@ -541,7 +541,7 @@ function chkserv_nginx_on {
         echo ""
         echo "=== Enable TailWatch chkservd driver for Nginx ==="
 
-        sed -i 's:service[httpd]=80,:service[httpd]=8080,:' /etc/chkserv.d/httpd
+        sed -i 's:service\[httpd\]=80,:service[httpd]=8080,:' /etc/chkserv.d/httpd
         echo "nginx:1" >> /etc/chkserv.d/chkservd.conf
         if [ ! -f /etc/chkserv.d/nginx ]; then
             touch /etc/chkserv.d/nginx
@@ -558,7 +558,7 @@ function chkserv_nginx_off {
         echo ""
         echo "=== Disable TailWatch chkservd driver for Nginx ==="
 
-        sed -i 's:service[httpd]=8080,:service[httpd]=80,:' /etc/chkserv.d/httpd
+        sed -i 's:service\[httpd\]=8080,:service[httpd]=80,:' /etc/chkserv.d/httpd
         sed -i 's:nginx\:1::' /etc/chkserv.d/chkservd.conf
         if [ -f /etc/chkserv.d/nginx ]; then
             /bin/rm -f /etc/chkserv.d/nginx

--- a/engintron.sh
+++ b/engintron.sh
@@ -542,6 +542,7 @@ function chkserv_nginx_on {
         echo "=== Enable TailWatch chkservd driver for Nginx ==="
 
         sed -i 's:service\[httpd\]=80,:service[httpd]=8080,:' /etc/chkserv.d/httpd
+        sed -i -e '$a\' /etc/chkserv.d/chkservd.conf
         echo "nginx:1" >> /etc/chkserv.d/chkservd.conf
         if [ ! -f /etc/chkserv.d/nginx ]; then
             touch /etc/chkserv.d/nginx
@@ -559,7 +560,7 @@ function chkserv_nginx_off {
         echo "=== Disable TailWatch chkservd driver for Nginx ==="
 
         sed -i 's:service\[httpd\]=8080,:service[httpd]=80,:' /etc/chkserv.d/httpd
-        sed -i 's:nginx\:1::' /etc/chkserv.d/chkservd.conf
+        sed -i '/^nginx:1/d' /etc/chkserv.d/chkservd.conf
         if [ -f /etc/chkserv.d/nginx ]; then
             /bin/rm -f /etc/chkserv.d/nginx
         fi

--- a/nginx/utilities/https_vhosts.php
+++ b/nginx/utilities/https_vhosts.php
@@ -79,12 +79,12 @@ server {
             foreach ($matches[1] as $vhost) {
                 if($hostnamePemFile && strpos($vhost, $hostnamePemFile)!== false) continue; // Skip the main hostname entry
                 preg_match("#ServerName (.+?)\n#s", $vhost, $name);
-                preg_match("#ServerAlias (.+?)\n#s", $vhost, $aliases);
+                preg_match_all("#ServerAlias (.+?)\n#s", $vhost, $aliases); // may have more than one line!
                 preg_match("#SSLCertificateFile (.+?)(\n|\r)#s", $vhost, $certfile);
                 preg_match("#SSLCertificateKeyFile (.+?)(\n|\r)#s", $vhost, $certkeyfile);
                 preg_match("#SSLCACertificateFile (.+?)(\n|\r)#s", $vhost, $certcafile);
                 if($aliases[1]){
-                    $vhostAliases = $aliases[1];
+                    $vhostAliases = implode(' ', $aliases[1]);
                 } else {
                     $vhostAliases = '';
                 }


### PR DESCRIPTION
Some virtual hosts have more than one ServerAlias line, and this modification joins up all the aliases into one big string.

Also, fixed replacing Apache port on chkservd config