### PR TITLE
Use source httpd template of chkservd

### DIFF
--- a/engintron.sh
+++ b/engintron.sh
@@ -543,11 +543,11 @@ function cron_for_https_vhosts_remove {
 }
 
 function chkserv_nginx_on {
-    if [ -f /etc/chkserv.d/httpd ]; then
+    if [ -f /usr/local/cpanel/src/chkservd/chkserv.d/httpd ]; then
         echo ""
         echo "=== Enable TailWatch chkservd driver for Nginx ==="
 
-        sed -i 's:service\[httpd\]=80,:service[httpd]=8080,:' /etc/chkserv.d/httpd
+        sed -i 's:service\[httpd\]=80,:service[httpd]=8080,:' /usr/local/cpanel/src/chkservd/chkserv.d/httpd
         echo "nginx:1" >> /etc/chkserv.d/chkservd.conf
         if [ ! -f /etc/chkserv.d/nginx ]; then
             touch /etc/chkserv.d/nginx
@@ -560,11 +560,11 @@ function chkserv_nginx_on {
 }
 
 function chkserv_nginx_off {
-    if [ -f /etc/chkserv.d/httpd ]; then
+    if [ -f /usr/local/cpanel/src/chkservd/chkserv.d/httpd ]; then
         echo ""
         echo "=== Disable TailWatch chkservd driver for Nginx ==="
 
-        sed -i 's:service\[httpd\]=8080,:service[httpd]=80,:' /etc/chkserv.d/httpd
+        sed -i 's:service\[httpd\]=8080,:service[httpd]=80,:' /usr/local/cpanel/src/chkservd/chkserv.d/httpd
         sed -i 's:^nginx\:1::' /etc/chkserv.d/chkservd.conf
         if [ -f /etc/chkserv.d/nginx ]; then
             /bin/rm -f /etc/chkserv.d/nginx


### PR DESCRIPTION
This PR updating the way of chkservd configuration as It would be better if the original template of `httpd` because cPanel overrides `/etc/chkserv.d/httpd` with `/usr/local/cpanel/src/chkservd/chkserv.d/httpd` so any direct modifications to `/etc/chkserv.d/httpd` wont be permanent . also if `/etc/chkserv.d/httpd` removed by mistake you will be able to restore it by restarting the chkservd service. Also reinstalling chkservd would override `/etc/chkserv.d/httpd` with the original one.

Note: The current nginx configuration for chkserv.d could be modified/enhanced by adding the nginx file to `/usr/local/cpanel/src/chkservd/chkserv.d/` then make reinstall to chkservd which enables nginx by default in this case so you wont need to append `nginx:1` the downside of this method that any services that is not disabled in a standard way will be activated again - this wont be a problem for new servers - but I don't know how we could provide persistent configuration which doesn't affect existing server. If the nginx method would be applicable I can create a separate PR for it

What do you think ?