### PR TITLE
Update proxy_params_dynamic to support IPB/IPS 4.x

### DIFF
--- a/nginx/proxy_params_dynamic
+++ b/nginx/proxy_params_dynamic
@@ -39,8 +39,14 @@ if ($http_cookie ~* "(joomla_[a-zA-Z0-9_]+|userID|wordpress_[a-zA-Z0-9_]+|wp-pos
     set $EXPIRES_FOR_DYNAMIC 0;
 }
 
-# Invision Community (IPS)
+# Invision Power Board (IPB) v3+
 if ($cookie_member_id ~ "^[1-9][0-9]*$") {
+    set $CACHE_BYPASS_FOR_DYNAMIC 1;
+    set $EXPIRES_FOR_DYNAMIC 0;
+}
+
+# Invision Power Board (IPB) v4+
+if ($cookie_ips4_member_id ~ "^[1-9][0-9]*$") {
     set $CACHE_BYPASS_FOR_DYNAMIC 1;
     set $EXPIRES_FOR_DYNAMIC 0;
 }


### PR DESCRIPTION
Added updated support for Invision Power Board/Suite 4.x so the cookies work and load correct. 
Initially proposed by  ChristianGabs but refined by me.