### PR TITLE
Added code for blocking wordpress wp-login.php brute force attack

### DIFF
--- a/nginx/common_http.conf
+++ b/nginx/common_http.conf
@@ -98,6 +98,12 @@ location = /favicon.ico {
     log_not_found off;
 }
 
+# To block brute force on wp-login
+location = /wp-login.php {
+    limit_req   zone=one  burst=1 nodelay;
+    include proxy_params_common;
+}   
+
 location = /robots.txt  {
     include proxy_params_common;
     include proxy_params_static;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -144,6 +144,9 @@ http {
     proxy_cache_path  /var/cache/nginx/engintron_static levels=1:2 keys_zone=engintron_static:20m inactive=10m max_size=512m;
     proxy_temp_path   /var/cache/nginx/engintron_temp;
 
+    # Rate limiting
+    limit_req_zone $binary_remote_addr zone=one:10m rate=1r/s;
+    
     ## Virtual Host Configs ##
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Hi Guys,

I've been managing many servers, most of them have Wordpress websites on it, some days I had servers overloaded due brute force attack being sent to wp-login.php that bypass the cache and affects Apache that use almost total resource available sometimes even turning the server down. 

So I Google some solutions and found this piece of code that indeed helped to stop this problem on my servers, I've put this code in 7 servers at moment and they stopped the problems with overload peaks... 

This code basically work when the attack happens, the robot that is doing the attack will get errors turning then the attack down.

Would be great have this available for everyone in the next updates.

Thank you