### PR TITLE
Fixes that Nginx only listen in IPV6 in new versions

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -10,7 +10,7 @@
 server {
 
     listen 80 default_server;
-    #listen [::]:80 default_server;
+    #listen [::]:80 default_server ipv6only=off;
 
     server_name localhost;
 

--- a/nginx/utilities/https_vhosts.php
+++ b/nginx/utilities/https_vhosts.php
@@ -51,7 +51,7 @@ function generate_https_vhosts()
 server {
 
     listen '.NGINX_HTTPS_PORT.' ssl http2 default_server;
-    #listen [::]:'.NGINX_HTTPS_PORT.' ssl http2 default_server;
+    #listen [::]:'.NGINX_HTTPS_PORT.' ssl http2 default_server ipv6only=off;;
     server_name localhost;
 
     # deny all; # DO NOT REMOVE OR CHANGE THIS LINE - Used when Engintron is disabled to block Nginx from becoming an open proxy


### PR DESCRIPTION
If you upgrade Nginx to a version greater than **1.3.4** and follow the manual to activate IPv6 in engintron you will find that your server **will only listen in IPv6**.

After a few hours of looking for solutions... it turns out that from version 1.3.4 by default is enabled `ipv6only=on`

With this simple change we avoid that the server is only listening in IPv6 (which at this stage of IPv6 implementation I think very few people will want to listen only in IPv6).

In case someone wants to activate only IPv6 they simply have to remove this option.