### PR TITLE
Ipv6 improvements for dual-stack services.

### DIFF
--- a/engintron.sh
+++ b/engintron.sh
@@ -39,9 +39,16 @@ function install_basics {
 function install_mod_remoteip {
 
     # Get system IPs
-    SYSTEM_IPS=$(ip addr show | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | sed ':a;N;$!ba;s/\n/ /g');
+    SYSTEM_IPv4=$(ip addr show | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | sed ':a;N;$!ba;s/\n/ /g');
+    SYSTEM_IPv6=$(ip addr show | grep -o "inet6 [0-9a-f:]*" | grep -v "fe80::[0-9a-f]*" | cut -c7- | sed ':a;N;$!ba;s/\n/ /g');
+    SYSTEM_IPS="$SYSTEM_IPv4 $SYSTEM_IPv6";
+    
     if [[ ! $(echo $SYSTEM_IPS | grep "127.0.0.1") ]]; then
         SYSTEM_IPS="127.0.0.1 $SYSTEM_IPS"
+    fi
+    
+    if [[ ! $(echo $SYSTEM_IPS | grep "::1") ]]; then
+        SYSTEM_IPS="::1 $SYSTEM_IPS"
     fi
 
     echo "=== Installing mod_remoteip for Apache ==="
@@ -137,9 +144,16 @@ function install_mod_rpaf {
     if [ -f /usr/local/apache/modules/mod_rpaf.so ]; then
 
         # Get system IPs
-        SYSTEM_IPS=$(ip addr show | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | sed ':a;N;$!ba;s/\n/ /g');
+        SYSTEM_IPv4=$(ip addr show | grep -o "inet [0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*" | sed ':a;N;$!ba;s/\n/ /g');
+        SYSTEM_IPv6=$(ip addr show | grep -o "inet6 [0-9a-f:]*" | grep -v "fe80::[0-9a-f]*" | cut -c7- | sed ':a;N;$!ba;s/\n/ /g');
+        SYSTEM_IPS="$SYSTEM_IPv4 $SYSTEM_IPv6";
+
         if [[ ! $(echo $SYSTEM_IPS | grep "127.0.0.1") ]]; then
             SYSTEM_IPS="127.0.0.1 $SYSTEM_IPS"
+        fi
+
+        if [[ ! $(echo $SYSTEM_IPS | grep "::1") ]]; then
+            SYSTEM_IPS="::1 $SYSTEM_IPS"
         fi
 
         if [ ! -f /usr/local/apache/conf/includes/rpaf.conf ]; then

--- a/engintron.sh
+++ b/engintron.sh
@@ -1141,24 +1141,24 @@ info)
 80)
     echo "=== Connections on port 80 (HTTP traffic) sorted by connection count & IP ==="
     echo ""
-    netstat -anp | grep :80 | awk '{print $5}' | cut -d: -f1 | sort | uniq -c | sort -n
+    netstat -anp | grep -P ':80\s' | awk '$6 !~ /LISTEN/ {print $5 " " $6 " " $7}' | sort | uniq -c | sort -n
     echo ""
     echo ""
     echo "=== Concurrent connections on port 80 (HTTP traffic) ==="
     echo ""
-    netstat -an | grep :80 | wc -l
+    netstat -an | grep -P ':80\s' | awk '$6 !~ /LISTEN/ {print $5}' | wc -l
     echo ""
     echo ""
     ;;
 443)
     echo "=== Connections on port 443 (HTTPS traffic) sorted by connection count & IP ==="
     echo ""
-    netstat -anp | grep :443 | awk '{print $5}' | cut -d: -f1 | sort | uniq -c | sort -n
+    netstat -anp | grep -P ':443\s' | awk '$6 !~ /LISTEN/ {print $5 " " $6 " " $7}' | sort | uniq -c | sort -n
     echo ""
     echo ""
     echo "=== Concurrent connections on port 443 (HTTPS traffic) ==="
     echo ""
-    netstat -an | grep :443 | wc -l
+    netstat -an | grep -P ':443\s' | awk '$6 !~ /LISTEN/ {print $5}' | wc -l
     echo ""
     echo ""
     ;;

--- a/nginx/common_http.conf
+++ b/nginx/common_http.conf
@@ -16,6 +16,16 @@ set $PROXY_DOMAIN_OR_IP $host;
 set $PROXY_FORWARDED_HOST $host;
 set $PROXY_SCHEME $scheme;
 set $SITE_URI "$host$request_uri";
+set $PROXY_IP_VERSION "6";
+
+# Detect IP Version
+# Due to `ipv6only=off` listen parameter, IPv4 will be embedded in IPv6.
+# If the IP is prefixed with ::ffff/96 we can assume it is IPv4
+if ($remote_addr ~* "^::ffff:\d+\.\d+\.\d+\.\d+$") {
+    set $PROXY_IP_VERSION "4";
+}
+set $PROXY_HOST_VERSION "${host}_ipv${PROXY_IP_VERSION}";
+
 
 # Generic query string to request a page bypassing Nginx's caching entirely for both dynamic & static content
 if ($query_string ~* "nocache") {
@@ -24,8 +34,11 @@ if ($query_string ~* "nocache") {
 }
 
 # Proxy requests to "localhost"
-if ($host ~* "localhost") {
+if ($PROXY_HOST_VERSION ~* "^localhost_ipv4$") {
     set $PROXY_DOMAIN_OR_IP "127.0.0.1";
+}
+if ($PROXY_HOST_VERSION ~* "^localhost_ipv6$") {
+    set $PROXY_DOMAIN_OR_IP "[::1]";
 }
 
 # Disable caching for cPanel specific subdomains

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -24,7 +24,7 @@ server {
         stub_status;
         access_log off;
         log_not_found off;
-        # Comment the following 2 lines to make the Nginx status page public
+        # Comment the following 3 lines to make the Nginx status page public
         allow 127.0.0.1;
         allow ::1;
         deny all;
@@ -32,7 +32,7 @@ server {
 
     location = /whm-server-status {
         proxy_pass http://127.0.0.1:8080; # Apache Status Page
-        # Comment the following 2 lines to make the Apache status page public
+        # Comment the following 3 lines to make the Apache status page public
         allow 127.0.0.1;
         allow ::1;
         deny all;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -34,6 +34,7 @@ server {
         proxy_pass http://127.0.0.1:8080; # Apache Status Page
         # Comment the following 2 lines to make the Apache status page public
         allow 127.0.0.1;
+        allow ::1;
         deny all;
     }
 }

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -24,10 +24,10 @@ server {
         stub_status;
         access_log off;
         log_not_found off;
-        # Uncomment the following 2 lines to make the Nginx status page private.
-        # If you do this and you have Munin installed, graphs for Nginx will stop working.
-        #allow 127.0.0.1;
-        #deny all;
+        # Comment the following 2 lines to make the Nginx status page public
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
     }
 
     location = /whm-server-status {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -59,6 +59,7 @@ http {
 
     ## Real IP Forwarding ##
     set_real_ip_from 127.0.0.1;
+    set_real_ip_from ::1;
 
     # CloudFlare IPs
     # List from: https://www.cloudflare.com/ips-v4

--- a/nginx/utilities/https_vhosts.php
+++ b/nginx/utilities/https_vhosts.php
@@ -69,7 +69,7 @@ server {
         stub_status;
         access_log off;
         log_not_found off;
-        # Comment the following 2 lines to make the Nginx status page public
+        # Comment the following 3 lines to make the Nginx status page public
         allow 127.0.0.1;
         allow ::1;
         deny all;
@@ -77,7 +77,7 @@ server {
 
     location = /whm-server-status {
         proxy_pass http://127.0.0.1:8080;
-        # Comment the following 2 lines to make the Apache status page public
+        # Comment the following 3 lines to make the Apache status page public
         allow 127.0.0.1;
         allow ::1;
         deny all;

--- a/nginx/utilities/https_vhosts.php
+++ b/nginx/utilities/https_vhosts.php
@@ -69,10 +69,10 @@ server {
         stub_status;
         access_log off;
         log_not_found off;
-        # Uncomment the following 2 lines to make the Nginx status page private.
-        # If you do this and you have Munin installed, graphs for Nginx will stop working.
-        #allow 127.0.0.1;
-        #deny all;
+        # Comment the following 2 lines to make the Nginx status page public
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
     }
 
     location = /whm-server-status {

--- a/nginx/utilities/https_vhosts.php
+++ b/nginx/utilities/https_vhosts.php
@@ -79,6 +79,7 @@ server {
         proxy_pass http://127.0.0.1:8080;
         # Comment the following 2 lines to make the Apache status page public
         allow 127.0.0.1;
+        allow ::1;
         deny all;
     }
 }


### PR DESCRIPTION
This PR includes changes to enable better IPv6 and Dual-Stack support with Engintron.  
It changes the install script to look for and include the system IPv6 addresses when generating the `mod_remoteip` and `mod_rpaf` configurations.  Primarily it changes nginx configs to allow/trust the IPv6 loopback address.

In addition, this PR adds connecting-client IP version detection which can be used to ensure IPv4 clients are forwarded to IPv4 servers or likewise with IPv6.   It also makes the status pages private by default, as munin functions normally with proper loopbacks allowed.

Merging this closes issue #1321 