### PR TITLE
Support websockets

### DIFF
--- a/app/engintron.php
+++ b/app/engintron.php
@@ -87,6 +87,7 @@ $allowed_files = array(
     '/etc/nginx/custom_rules',
     '/etc/nginx/nginx.conf',
     '/etc/nginx/proxy_params_common',
+	'/etc/nginx/proxy_params_common_ws',
     '/etc/nginx/proxy_params_dynamic',
     '/etc/nginx/proxy_params_static'
 );

--- a/app/engintron.php
+++ b/app/engintron.php
@@ -575,6 +575,7 @@ echo str_replace($output_find, $output_replace, $output);
                             <li><a href="engintron.php?op=edit&f=/etc/nginx/custom_rules&s=nginx">Edit your custom_rules for Nginx</a><?php if (file_exists('/etc/nginx/custom_rules.dist')): ?><span>(<a class="ngViewDefault" href="engintron.php?op=view&f=/etc/nginx/custom_rules.dist">view default</a>)</span><?php endif; ?></li>
                             <li><a href="engintron.php?op=edit&f=/etc/nginx/conf.d/default.conf&s=nginx">Edit default.conf</a></li>
                             <li><a href="engintron.php?op=edit&f=/etc/nginx/proxy_params_common&s=nginx">Edit proxy_params_common</a></li>
+							<li><a href="engintron.php?op=edit&f=/etc/nginx/proxy_params_common_ws&s=nginx">Edit proxy_params_common_ws</a></li>
                             <li><a href="engintron.php?op=edit&f=/etc/nginx/proxy_params_dynamic&s=nginx">Edit proxy_params_dynamic</a></li>
                             <li><a href="engintron.php?op=edit&f=/etc/nginx/proxy_params_static&s=nginx">Edit proxy_params_static</a></li>
                             <li><a href="engintron.php?op=edit&f=/etc/nginx/common_http.conf&s=nginx">Edit common_http.conf</a></li>

--- a/nginx/common_http.conf
+++ b/nginx/common_http.conf
@@ -40,28 +40,33 @@ if ($host ~* "^webmail\.") {
     set $PROXY_FORWARDED_HOST '';
 }
 
-if ($PROXY_SCHEME ~* "ws|wss") {
-	set $WEBSOCKET_UPGRADE 1;
-	set $PROXY_SCHEME "http";
-}
-
 # Set custom rules like domain/IP exclusions or redirects here
 include custom_rules;
 
+set $NGINX_LOCATION_BLOCK "backend";
+if ($WEBSOCKET_UPGRADE) {
+	set $CACHE_BYPASS_FOR_DYNAMIC 1;
+	set $CACHE_BYPASS_FOR_STATIC 1;
+	set $NGINX_LOCATION_BLOCK "backendws";
+}
+
 location / {
-    try_files $uri $uri/ @backend;
+    try_files $uri $uri/ @$NGINX_LOCATION_BLOCK;
 }
 
 location @backend {
+    
+    include proxy_params_common;
 
-	if ($WEBSOCKET_UPGRADE) {
-		include proxy_params_common_ws;
-    }
-	
-	if (!$WEBSOCKET_UPGRADE) {
-		include proxy_params_common;
-    }
-	
+	# === MICRO CACHING ===
+    # Comment the following line to disable 1 second micro-caching for dynamic HTML content
+    include proxy_params_dynamic;
+}
+
+location @backendws {
+
+    include proxy_params_common_ws;
+    
 	# === MICRO CACHING ===
     # Comment the following line to disable 1 second micro-caching for dynamic HTML content
     include proxy_params_dynamic;

--- a/nginx/common_http.conf
+++ b/nginx/common_http.conf
@@ -10,6 +10,7 @@
 # Common definitions for HTTP content
 
 # Initialize important variables
+set $WEBSOCKET_UPGRADE 0;
 set $CACHE_BYPASS_FOR_DYNAMIC 0;
 set $CACHE_BYPASS_FOR_STATIC 0;
 set $PROXY_DOMAIN_OR_IP $host;
@@ -39,6 +40,11 @@ if ($host ~* "^webmail\.") {
     set $PROXY_FORWARDED_HOST '';
 }
 
+if ($PROXY_SCHEME ~* "ws|wss") {
+	set $WEBSOCKET_UPGRADE 1;
+	set $PROXY_SCHEME "http";
+}
+
 # Set custom rules like domain/IP exclusions or redirects here
 include custom_rules;
 
@@ -47,8 +53,16 @@ location / {
 }
 
 location @backend {
-    include proxy_params_common;
-    # === MICRO CACHING ===
+
+	if ($WEBSOCKET_UPGRADE) {
+		include proxy_params_common_ws;
+    }
+	
+	if (!$WEBSOCKET_UPGRADE) {
+		include proxy_params_common;
+    }
+	
+	# === MICRO CACHING ===
     # Comment the following line to disable 1 second micro-caching for dynamic HTML content
     include proxy_params_dynamic;
 }

--- a/nginx/custom_rules
+++ b/nginx/custom_rules
@@ -93,7 +93,6 @@
 # }
 
 
-
 # === HOST NODE (OR OTHER NON-PHP) APSS ON CPANEL ===
 # One of the nice-to-have things with Engintron is that it makes it a breeze to proxy requests to any port in your server, supporting apps that would never otherwise work with standard cPanel domains. Such an example is a Node.js app running on port 3000 or ElasticSearch, a popular search engine written in Java (works on port 9200), which usually comes with frontends that also work on non-standard web ports (e.g. Cerebro uses port 9000).
 #
@@ -116,5 +115,11 @@
 # if ($host = "app.mynodeapp.com") {
 #     set $PROXY_SCHEME "http";
 #     set $PROXY_TO_PORT 3000;
+#     set $WEBSOCKET_UPGRADE 1;
+# }
+#
+# Auto enable WEBSOCKETS for subdomains with name ws.mynodeapp.com or wss.mynodeapp.com or appws.mynodeapp.com
+# if ($SITE_URI ~* "^(ws|wss|appws)\.") {
+#     set $PROXY_SCHEME "http";
 #     set $WEBSOCKET_UPGRADE 1;
 # }

--- a/nginx/custom_rules
+++ b/nginx/custom_rules
@@ -108,6 +108,7 @@
 # if ($host ~ "mynodeapp.com") {
 #     set $PROXY_SCHEME "http";
 #     set $PROXY_TO_PORT 3000;
+#     set $WEBSOCKET_UPGRADE 1;
 # }
 #
 # If you want the app to proxy a certain subdomain, make the rule stricter (replacing ~ with =):
@@ -115,4 +116,5 @@
 # if ($host = "app.mynodeapp.com") {
 #     set $PROXY_SCHEME "http";
 #     set $PROXY_TO_PORT 3000;
+#     set $WEBSOCKET_UPGRADE 1;
 # }

--- a/nginx/proxy_params_common_ws
+++ b/nginx/proxy_params_common_ws
@@ -1,0 +1,38 @@
+# /**
+#  * Forked by: Stergios Zgouletas / WEB EXPERT SERVICES LTD : WebSocket Support
+#  * @version    2.1
+#  * @package    Engintron for cPanel/WHM
+#  * @author     Fotis Evangelou (https://kodeka.io)
+#  * @url        https://engintron.com
+#  * @copyright  Copyright (c) 2014 - 2022 Kodeka OÜ. All rights reserved.
+#  * @license    GNU/GPL license: https://www.gnu.org/copyleft/gpl.html
+#  */
+
+# General Proxy Settings
+proxy_pass                    $PROXY_SCHEME://$PROXY_DOMAIN_OR_IP:$PROXY_TO_PORT;
+proxy_http_version            1.1;                # Always upgrade to HTTP/1.1
+proxy_set_header              Accept-Encoding ""; # Optimize encoding
+proxy_set_header 			  Upgrade $http_upgrade;
+proxy_set_header			  Connection "upgrade"; # Enable keepalives
+proxy_set_header              Host $host;
+proxy_set_header              Proxy "";
+proxy_set_header              Referer $http_referer;
+proxy_set_header              X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header              X-Forwarded-Host $PROXY_FORWARDED_HOST;
+proxy_set_header              X-Forwarded-Port $server_port;
+proxy_set_header              X-Forwarded-Proto $scheme;
+proxy_set_header              X-Forwarded-Server $host;
+proxy_set_header              X-Real-IP $remote_addr;
+proxy_set_header              CF-Connecting-IP $http_cf_connecting_ip;
+proxy_set_header              CF-Visitor $http_cf_visitor;
+
+# Buffers
+proxy_buffers                 256 16k;
+proxy_buffer_size             128k;
+proxy_busy_buffers_size       256k;
+proxy_temp_file_write_size    256k;
+
+# Timeouts
+proxy_connect_timeout         300s;
+proxy_read_timeout            600s;
+proxy_send_timeout            600s;


### PR DESCRIPTION
This PULL request has a new feature, WEBSOCKET SUPPORT,
a VARIABLE to enable the websocket-upgrade for specific rules and also separate file for websocket connection 
https://prnt.sc/i1oveQgGpfqK

if ($host = "app.mynodeapp.com") {
     set $PROXY_SCHEME "http";
     set $PROXY_TO_PORT 3000;
     set $WEBSOCKET_UPGRADE 1;
}

Solution provided here works well but causes some issue on some browsers (Safari)
https://github.com/engintron/engintron/issues/801#issuecomment-502110747

I hope to accept these changes @fevangelou 